### PR TITLE
Bind lookup to form submit

### DIFF
--- a/public/javascripts/scripts.js
+++ b/public/javascripts/scripts.js
@@ -42,10 +42,11 @@ function getDataFromGithub(username) {
 }
 
 $(function () {
-    $("#checkbutton").click(function () {
+    $("#ghform").submit(function () {
         var ghuser = $("#ghuser").val();
         if (ghuser != "") {
             getDataFromGithub(ghuser);
         }
+        return false;
     });
 });

--- a/views/index.jade
+++ b/views/index.jade
@@ -17,8 +17,9 @@ block body
 
         .row
             .col-md-4
-                +input("text","ghuser","Github Username","Github Username","ghuser")
-                +submit2("Check","default","checkbutton")
+                form#ghform
+                    +input("text","ghuser","Github Username","Github Username","ghuser")
+                    +submit2("Check","default","checkbutton")
 
         .row
             h3#total Total PR's: 0


### PR DESCRIPTION
This will change triggering the PR lookup to the submit event on a form. That allows a user to press enter after typing a username in addition to clicking the 'Check' button.
