### PR TITLE
fix nitrous.io link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 4. navigate to yourIp:3000
 
 ## Nitrous Quickstart
-Setup your own development environment on [nitrous.io](www.nitrous.io).
+Setup your own development environment on [nitrous.io](https://www.nitrous.io).
 
 [![Nitrous Quickstart](https://nitrous-image-icons.s3.amazonaws.com/quickstart.svg)](https://www.nitrous.io/quickstart?repo=https://github.com/spezzino/hfchecker)
 


### PR DESCRIPTION
Without the protocol specified, it acted as a relative link within this github repo.
