### PR TITLE
Fix fork me banner

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -56,7 +56,7 @@ html(lang="en")
             link(rel="stylesheet",href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css")
 
     body(data-spy="scroll",data-target=".scrollspy")
-        a(href="https://github.com/spezzino/hfchecker" title="Fork me on GitHub").github-fork-ribbon Fork me on GitHub
+        a(href="https://github.com/spezzino/hfchecker" title="Fork me on GitHub").github-fork-ribbon.fixed Fork me on GitHub
         block body
 
         block scripts


### PR DESCRIPTION
The "fork me on github" banner was positioned absolutely, meaning it scrolled with the main content, while it was positioned "on top" of the fixed navigation bar. This arrangement does not make sense (during scrolling, the navbar had content scrolling both above and below it).

What does make sense is either of these two optons:
- make the fork me banner position:fixed, so it stays together with the navbar
- keep the fork me banner position:absolute, but move it under the navbar

This PR implements the first option above, as I think it makes the most sense.
