### PR TITLE
Filter out invalid pull requests

### DIFF
--- a/public/javascripts/scripts.js
+++ b/public/javascripts/scripts.js
@@ -1,5 +1,5 @@
 function getDataFromGithub(username) {
-    var url = "https://api.github.com/search/issues?q=author:" + username + "+type:pr+created:2016-10-01..2016-10-31";
+    var url = "https://api.github.com/search/issues?q=author:" + username + "+type:pr+-label:invalid+created:2016-10-01..2016-10-31";
 
     var results = $("#results");
     results.html("");


### PR DESCRIPTION
According to [this tweet](https://twitter.com/digitalocean/status/783763569812832256), pull requests will not be counted toward Hacktoberfest if they are labelled as "invalid". This change excludes those issues from the search results.
