### PR TITLE
Extend PR search pagination limit

### DIFF
--- a/public/javascripts/scripts.js
+++ b/public/javascripts/scripts.js
@@ -1,5 +1,5 @@
 function getDataFromGithub(username) {
-    var url = "https://api.github.com/search/issues?q=author:" + username + "+type:pr+-label:invalid+created:2016-10-01..2016-10-31";
+    var url = "https://api.github.com/search/issues?per_page=1000&q=author:" + username + "+type:pr+-label:invalid+created:2016-10-01..2016-10-31";
 
     var results = $("#results");
     results.html("");


### PR DESCRIPTION
By default GitHub limits the number of search results to 1000.  The output
is then paginated with a limit of 30 items per page, hence some users who
had submitted more than 30 PRs were seeing only a maximum of 30 PRs
submitted in October.  This commit increases the number of items per page
and hence allows the user to see all PRs that they have submitted in
Hacktoberfest.
